### PR TITLE
Can't run os-packer builds on draft releases, so add support for using the assets/ dir

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -11,12 +11,17 @@ ENV DAPPER_RUN_ARGS --device=/dev/kvm:/dev/kvm
 ENV DAPPER_OUTPUT ./dist
 WORKDIR ${DAPPER_SOURCE}
 
-ENV RANCHEROS_VERSION v0.8.0-rc1
+ENV RANCHEROS_VERSION v0.8.0-rc2
 ENV AWS_IMAGE_BUILD_NUMBER 1
 
+COPY assets/* /
 RUN cd / \
-    && wget https://github.com/rancher/os/releases/download/${RANCHEROS_VERSION}/rancheros.iso \
-    && wget https://github.com/rancher/os/releases/download/${RANCHEROS_VERSION}/iso-checksums.txt
+    && if [ ! -f /rancheros.iso ]; then \
+        wget https://github.com/rancher/os/releases/download/${RANCHEROS_VERSION}/rancheros.iso \
+    ;fi \
+    && if [ ! -f /iso-checksums.txt ]; then \
+        wget https://github.com/rancher/os/releases/download/${RANCHEROS_VERSION}/iso-checksums.txt \
+    ;fi
 
 ENTRYPOINT ["./scripts/entry"]
 CMD ["ci"]

--- a/assets/README.assets
+++ b/assets/README.assets
@@ -1,0 +1,1 @@
+if you copy a rancheros.iso and iso-checksums.txt file into this dir, then the build will use it


### PR DESCRIPTION
plus rc2 - as that's what i needed it for :)

Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>