### PR TITLE
Add vSphere support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ output
 dist/
 account.json
 /.dapper
+packer_cache

--- a/scripts/install2disk
+++ b/scripts/install2disk
@@ -127,6 +127,23 @@ EOF
         sudo ros install -d /dev/sda -f -c ./vagrant.yml --no-reboot
         ;;
 
+    "vmware-iso")
+        cat >cloud-config.yml<<EOF
+#cloud-config
+rancher:
+  services_include:
+    open-vm-tools: true
+EOF
+        sudo ros install -d /dev/sda -f -c ./cloud-config.yml --no-reboot
+        sudo mkdir /mnt/install
+        sudo mount /dev/sda1 /mnt/install
+        sudo mkdir -p /mnt/install/var/lib/rancher/preload/system-docker
+        sudo mkdir /mnt/install/var/lib/rancher/cache
+        sudo system-docker save rancher/os-openvmtools | xz > os-openvmtools.xz
+        sudo mv os-openvmtools.xz /mnt/install/var/lib/rancher/preload/system-docker/
+        sudo cp /var/lib/rancher/cache/* /mnt/install/var/lib/rancher/cache/
+        ;;
+
     "amazon-ebs")
         echo "building amazon-ebs"
         cat >cloud-config.yml<<EOF

--- a/vsphere/README.md
+++ b/vsphere/README.md
@@ -1,0 +1,50 @@
+# RancherOS vSphere Build
+
+These builds do not supply a `cloud-config.yml` file. This is expected to be included when deploying the template in vSphere via the `guestinfo` fields.
+
+## Example Build without Uploading to vSphere
+
+This build will create the VM and store it in the `output-rancheros-1.4.3` directory.
+
+```
+export RANCHEROS_VERSION=1.4.3
+export ISO_CHECKSUM=e9b92ebba06383653b6ad2da404326a0
+export PACKER_BOOT_WAIT=120s
+
+packer build -except=vsphere-upload ./vsphere.json
+```
+
+## Example with vSphere Upload
+
+This will create the VM and then upload it to vSphere and mark it as a template.
+
+```
+export RANCHEROS_VERSION=1.4.3
+export ISO_CHECKSUM=e9b92ebba06383653b6ad2da404326a0
+export PACKER_BOOT_WAIT=120s
+
+export GOVC_URL=your-vcsa.url.here
+export GOVC_INSECURE=true
+export GOVC_USERNAME=administrator@vsphere.local
+export GOVC_PASSWORD=yourpassword
+export GOVC_DATACENTER=yourdatacenter
+export GOVC_CLUSTER=yourcluster
+export GOVC_DATASTORE=yourdatastore
+export GOVC_VM_NETWORK=yournetwork
+export GOVC_VM_FOLDER=yourfolder
+
+packer build ./vsphere.json
+```
+
+## Terraform Details
+
+When deploying the template with Terraform, you will need to include the `cloud-config` data by adding a `template_file` and rendering the content into the `guestinfo` fields.
+
+Add this to your VM resource:
+
+```
+  extra_config {
+    "guestinfo.cloud-init.config.data" = "${base64encode("${data.template_file.nameoftemplate.rendered}")}"
+    "guestinfo.cloud-init.data.encoding" = "base64"
+  }
+```

--- a/vsphere/vsphere.json
+++ b/vsphere/vsphere.json
@@ -1,0 +1,73 @@
+{
+  "variables": {
+    "version": "{{ env `RANCHEROS_VERSION` }}",
+    "checksum": "{{ env `ISO_CHECKSUM` }}",
+    "boot_wait": "{{ env `PACKER_BOOT_WAIT` }}",
+    "vsphere_cluster": "{{ env `GOVC_CLUSTER` }}",
+    "vsphere_datacenter": "{{ env `GOVC_DATACENTER` }}",
+    "vsphere_datastore": "{{ env `GOVC_DATASTORE` }}",
+    "vsphere_host": "{{ env `GOVC_URL` }}",
+    "vsphere_password": "{{ env `GOVC_PASSWORD` }}",
+    "vsphere_username": "{{ env `GOVC_USERNAME` }}",
+    "vsphere_insecure": "{{ env `GOVC_INSECURE` }}",
+    "vsphere_vm_folder": "{{ env `GOVC_VM_FOLDER` }}",
+    "vsphere_vm_network": "{{ env `GOVC_VM_NETWORK` }}"
+  },
+  "builders":[{
+    "name": "rancheros-{{ user `version` }}",
+    "type": "vmware-iso",
+    "guest_os_type": "otherLinux-64",
+    "iso_url": "https://github.com/rancher/os/releases/download/v{{ user `version` }}/rancheros.iso",
+    "iso_checksum": "{{ user `checksum` }}",
+    "iso_checksum_type": "md5",
+    "ssh_username": "rancher",
+    "ssh_password": "rancher",
+    "headless": true,
+    "boot_command": [
+      "sudo -i<enter>",
+      "echo rancher:rancher | chpasswd<enter>"
+    ],
+    "boot_wait": "{{user `boot_wait`}}",
+    "ssh_wait_timeout": "240s",
+    "shutdown_command": "sudo shutdown -h now",
+    "disk_size":"16384",
+    "vm_name":"rancheros-{{ user `version` }}",
+    "cpus": "2",
+    "memory": "2048",
+    "network_adapter_type": "vmxnet3"
+  }],
+  "provisioners":[{
+    "type": "shell",
+    "scripts": [
+      "../scripts/install2disk"
+    ]
+  }],
+  "post-processors": [
+    [
+      {
+        "name": "vsphere-upload",
+        "type": "vsphere",
+        "cluster": "{{ user `vsphere_cluster` }}",
+        "datacenter": "{{ user `vsphere_datacenter` }}",
+        "datastore": "{{ user `vsphere_datastore` }}",
+        "host": "{{ user `vsphere_host` }}",
+        "password": "{{ user `vsphere_password` }}",
+        "username": "{{ user `vsphere_username` }}",
+        "insecure": "{{ user `vsphere_insecure` }}",
+        "vm_name": "rancheros-{{ user `version` }}",
+        "disk_mode": "thin",
+        "vm_folder": "{{ user `vsphere_vm_folder` }}",
+        "vm_network": "{{ user `vsphere_vm_network` }}"
+      },
+      {
+        "type": "vsphere-template",
+        "host": "{{ user `vsphere_host` }}",
+        "password": "{{ user `vsphere_password` }}",
+        "username": "{{ user `vsphere_username` }}",
+        "insecure": "{{ user `vsphere_insecure` }}",
+        "datacenter": "{{ user `vsphere_datacenter` }}",
+        "folder": "{{ user `vsphere_vm_folder` }}"
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
Added a simple config for building a vSphere template. It uses the standard `rancheros.iso` and then adds in the os-openvmtools image and service after the install.