### PR TITLE
Exoscale: leave image as a qcow2 instead of img

### DIFF
--- a/scripts/build-exoscale
+++ b/scripts/build-exoscale
@@ -10,9 +10,8 @@ PACKER_LOG=1 packer build ${FILE:-exoscale-qemu.json}
 RANCHEROS_VERSION=${RANCHEROS_VERSION:-test}
 
 mv output-exoscale/packer-exoscale rancheros-exoscale.qcow2
-qemu-img convert -c -O qcow2 rancheros-exoscale.qcow2 rancheros-exoscale.img
 mkdir -p ../dist
-mv rancheros-exoscale.img ../dist/
+mv rancheros-exoscale.qcow2 ../dist/
 
 echo "upload the Exoscale image using:"
 echo "  gsutil cp dist/rancheros-exoscale.img gs://releases.rancher.com/os/latest/rancheros-exoscale.img"


### PR DESCRIPTION
More simple for us if we are leaving image as a qcow2.

Thank you 😃 

ps:
Do you think can be possible to update the assets in:
https://github.com/rancher/os/releases/tag/v1.5.5 ?